### PR TITLE
Publish the plugin to plugin portal

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,4 +28,4 @@ jobs:
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
         uses: burrunan/gradle-cache-action@v1
         with:
-          arguments: publish
+          arguments: publishPlugins

--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ plugins {
 ```
 
 This plugin requires `co.bound.codeartifact` plugin to also be applied in the `settings.gradle` and a CodeArtifact
-repository to be configured. It will apply the `mavne-publish` plugin and add the configured CodeArtifact repository
+repository to be configured. It will apply the `maven-publish` plugin and add the configured CodeArtifact repository
 as a publishing repository.


### PR DESCRIPTION
Use the correct task to publish to the portal: https://docs.gradle.org/current/userguide/publishing_gradle_plugins.html#publish_your_plugin_to_the_plugin_portal

And also fix the typo in README.