### PR TITLE
Enable repository filtering

### DIFF
--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "co.bound"
-version = "1.4.0"
+version = "1.4.1"
 
 tasks.named("publish") {
     dependsOn("check")

--- a/plugins/src/main/java/co/bound/codeartifact/CodeArtifactPluginExtension.java
+++ b/plugins/src/main/java/co/bound/codeartifact/CodeArtifactPluginExtension.java
@@ -1,5 +1,7 @@
 package co.bound.codeartifact;
 
+import co.bound.codeartifact.internal.SerializableAction;
+import org.gradle.api.artifacts.repositories.MavenRepositoryContentDescriptor;
 import org.gradle.api.provider.Property;
 
 public abstract class CodeArtifactPluginExtension {
@@ -10,4 +12,6 @@ public abstract class CodeArtifactPluginExtension {
     public abstract Property<String> getRegion();
 
     public abstract Property<String> getRepo();
+
+    public abstract Property<SerializableAction<MavenRepositoryContentDescriptor>> getMavenContent();
 }

--- a/plugins/src/main/java/co/bound/codeartifact/CodeArtifactRepoProvider.java
+++ b/plugins/src/main/java/co/bound/codeartifact/CodeArtifactRepoProvider.java
@@ -1,7 +1,9 @@
 package co.bound.codeartifact;
 
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
+import org.gradle.api.Action;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.api.artifacts.repositories.MavenRepositoryContentDescriptor;
 import org.gradle.api.provider.Property;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
@@ -16,6 +18,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.Properties;
 
 public abstract class CodeArtifactRepoProvider implements BuildService<CodeArtifactRepoProvider.Params> {
@@ -39,6 +42,8 @@ public abstract class CodeArtifactRepoProvider implements BuildService<CodeArtif
                 }
             }
         });
+        Optional.ofNullable(params.getMavenContent().getOrNull())
+                .ifPresent(spec::mavenContent);
     }
 
     private GetAuthorizationTokenResponse token = null;
@@ -139,5 +144,7 @@ public abstract class CodeArtifactRepoProvider implements BuildService<CodeArtif
         Property<File> getGradleUserHome();
 
         Property<Boolean> getOffline();
+
+        Property<Action<MavenRepositoryContentDescriptor>> getMavenContent();
     }
 }

--- a/plugins/src/main/java/co/bound/codeartifact/SettingsPlugin.java
+++ b/plugins/src/main/java/co/bound/codeartifact/SettingsPlugin.java
@@ -29,6 +29,7 @@ public class SettingsPlugin implements Plugin<Settings> {
                     params.getAccountId().set(codeartifact.getAccountId());
                     params.getRegion().set(codeartifact.getRegion());
                     params.getRepo().set(codeartifact.getRepo());
+                    params.getMavenContent().set(codeartifact.getMavenContent());
                     params.getGradleUserHome().set(settings.getStartParameter().getGradleUserHomeDir());
                     params.getOffline().set(settings.getStartParameter().isOffline());
                 }));

--- a/plugins/src/main/java/co/bound/codeartifact/internal/SerializableAction.java
+++ b/plugins/src/main/java/co/bound/codeartifact/internal/SerializableAction.java
@@ -1,0 +1,8 @@
+package co.bound.codeartifact.internal;
+
+import org.gradle.api.Action;
+
+import java.io.Serializable;
+
+public interface SerializableAction<T> extends Action<T>, Serializable {
+}

--- a/plugins/src/test/groovy/co/bound/codeartifact/CodeArtifactPluginTest.groovy
+++ b/plugins/src/test/groovy/co/bound/codeartifact/CodeArtifactPluginTest.groovy
@@ -2,7 +2,13 @@ package co.bound.codeartifact
 
 import org.gradle.util.GradleVersion
 
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl
+import static com.github.tomakehurst.wiremock.client.WireMock.get
+import static com.github.tomakehurst.wiremock.client.WireMock.head
+import static com.github.tomakehurst.wiremock.client.WireMock.ok
+import static com.github.tomakehurst.wiremock.client.WireMock.okXml
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching
+import static com.github.tomakehurst.wiremock.http.RequestMethod.GET
 import static com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.allRequests
 import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.newRequestPattern
@@ -49,6 +55,7 @@ class CodeArtifactPluginTest extends PluginTest {
         result.output.contains("Searched in the following repositories:")
         result.output.contains("codeartifact(${wiremock.baseUrl()}/${domain}-${accountId}.d.codeartifact.${region}.amazonaws.com/maven/$repo/)")
         wiremock.verify(1, newRequestPattern(POST, urlMatching("/v1/authorization-token.*")))
+        wiremock.verify(1, newRequestPattern(GET, anyUrl()))
 
         where:
         gradleVersion << gradleVersions()
@@ -64,7 +71,7 @@ class CodeArtifactPluginTest extends PluginTest {
             plugins {
                 id("co.bound.codeartifact")
             }
-            codeartifact{
+            codeartifact {
                 domain.set("$domain")
                 accountId.set("$accountId")
                 region.set("$region")
@@ -89,9 +96,52 @@ class CodeArtifactPluginTest extends PluginTest {
         result.output.contains("Searched in the following repositories:")
         result.output.contains("codeartifact(${wiremock.baseUrl()}/${domain}-${accountId}.d.codeartifact.${region}.amazonaws.com/maven/$repo/)")
         wiremock.verify(1, newRequestPattern(POST, urlMatching("/v1/authorization-token.*")))
+        wiremock.verify(1, newRequestPattern(GET, anyUrl()))
 
         where:
         gradleVersion << gradleVersions()
+    }
+
+    def "can configure repository filters"() {
+        given:
+        givenCodeArtifactWillReturnAuthToken()
+        file("gradle.properties") << "systemProp.org.gradle.unsafe.kotlin.assignment=true"
+        def settingsKt = file('settings.gradle.kts')
+        settingsFile.renameTo(settingsKt)
+        settingsFile = settingsKt
+        settingsFile.setText("""
+            plugins {
+                id("co.bound.codeartifact")
+            }
+            codeartifact {
+                domain = "$domain"
+                accountId = "$accountId"
+                region = "$region"
+                repo = "$repo"
+                mavenContent.set() {
+                    includeGroup("foo.other") 
+                }
+            }
+            ${settingsFile.text}
+        """)
+        def buildKt = file('build.gradle.kts')
+        buildFile.renameTo(buildKt)
+        buildFile = buildKt
+        buildFile << """
+            plugins {
+                id("foo.bar").version("42")
+            }
+        """
+
+        when:
+        def result = runTaskWithFailure(GradleVersion.current().getVersion(), "tasks", "-i")
+
+        then:
+        result.output.contains("Plugin [id: 'foo.bar', version: '42'] was not found in any of the following sources:")
+        result.output.contains("Searched in the following repositories:")
+        result.output.contains("codeartifact(${wiremock.baseUrl()}/${domain}-${accountId}.d.codeartifact.${region}.amazonaws.com/maven/$repo/)")
+        wiremock.verify(1, newRequestPattern(POST, urlMatching("/v1/authorization-token.*")))
+        wiremock.verify(0, newRequestPattern(GET, anyUrl()))
     }
 
     def "does not fetch the token for offline mode"() {
@@ -121,29 +171,53 @@ class CodeArtifactPluginTest extends PluginTest {
         given:
         givenCodeArtifactWillReturnAuthToken()
         givenCodeArtifactPluginIsConfigured()
+        wiremock.stubFor(head(anyUrl()).willReturn(ok()))
+        wiremock.stubFor(get(urlMatching(".*/42-SNAPSHOT/maven-metadata.xml"))
+                .willReturn(okXml("""\
+            <metadata>
+              <groupId>foo</groupId>
+              <artifactId>bar</artifactId>
+              <versioning>
+                <versions>
+                  <version>42-SNAPSHOT</version>
+                </versions>
+              </versioning>
+            </metadata>""".stripIndent())))
+        wiremock.stubFor(get(urlMatching(".*/bar-42-SNAPSHOT.pom"))
+                .willReturn(okXml("""\
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>foo</groupId>
+              <artifactId>bar</artifactId>
+              <version>42-SNAPSHOT</version>
+            </project>""".stripIndent())))
+        wiremock.stubFor(get(urlMatching(".*/bar-42-SNAPSHOT.pom.sha1")).willReturn(ok("1")))
+        wiremock.stubFor(get(urlMatching(".*/bar-42-SNAPSHOT.jar"))
+        // minimal empty zip file
+                .willReturn(ok().withBody(new byte[]{0x50, 0x4B, 0x05, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})))
+        wiremock.stubFor(get(urlMatching(".*/bar-42-SNAPSHOT.jar.sha1")).willReturn(ok("2")))
         buildFile << """
             plugins {
                 id("java") 
             }
             dependencies {
-                implementation("foo:bar:42")
+                implementation("foo:bar:42-SNAPSHOT")
             }
         """
-        file("src/main/java/Foo.java") << "class Foo {}"
+        file("src/main/java/bar").mkdirs()
+        file("src/main/java/bar/Foo.java") << """\
+            package bar;
+            class Foo {}""".stripIndent()
 
         when:
-        def result1 = runTaskWithFailure(gradleVersion, "build")
-        def result2 = runTaskWithFailure(gradleVersion, "build")
+        runTask(gradleVersion, "build", "-i")
+        runTask(gradleVersion, "build", "--refresh-dependencies")
 
         then:
-        result1.output.contains("Could not find foo:bar:42")
-        result1.output.contains("Searched in the following locations")
-        result1.output.contains("- ${wiremock.baseUrl()}/${domain}-${accountId}.d.codeartifact.${region}.amazonaws.com/maven/$repo/foo/bar/42/bar-42.pom")
-        result2.output.contains("Could not find foo:bar:42")
-        result2.output.contains("Searched in the following locations")
-        result2.output.contains("- ${wiremock.baseUrl()}/${domain}-${accountId}.d.codeartifact.${region}.amazonaws.com/maven/$repo/foo/bar/42/bar-42.pom")
         // credentials are cached
         wiremock.verify(1, newRequestPattern(POST, urlMatching("/v1/authorization-token.*")))
+        wiremock.verify(2, newRequestPattern(GET, urlMatching(".*/bar-42-SNAPSHOT.jar")))
+        wiremock.findAllUnmatchedRequests().isEmpty()
 
         where:
         gradleVersion << gradleVersions()

--- a/plugins/src/test/groovy/co/bound/codeartifact/PluginTest.groovy
+++ b/plugins/src/test/groovy/co/bound/codeartifact/PluginTest.groovy
@@ -88,9 +88,10 @@ abstract class PluginTest extends Specification {
         return ["7.6.1", "8.0.2", GradleVersion.current().getVersion()]
     }
 
-    BuildResult runTask(String task) {
+    BuildResult runTask(Object gradleVersion, String... tasks) {
         def result = gradleRunner
-                .withArguments(task, '--stacktrace')
+                .withGradleVersion(gradleVersion as String)
+                .withArguments((tasks + ['--stacktrace']) as List<String>)
                 .build()
         println(result.output)
         return result


### PR DESCRIPTION
Users can configure the MavenRepositoryContentDescriptor to only include certain packages from reporitory.