### PR TITLE
Allow CodeArtifact repo customization via default Gradle APIs

### DIFF
--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "co.bound"
-version = "1.4.0"
+version = "1.4.1"
 
 tasks.named("publish") {
     dependsOn("check")

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -17,7 +17,6 @@ tasks.named("publish") {
 tasks.named("test", Test) {
     useJUnitPlatform()
     testLogging.exceptionFormat = 'full'
-    testLogging.events("started", "skipped", "failed")
     def tmpDir = file("$buildDir/tmp/test/work")
     tmpDir.mkdirs()
     systemProperty 'java.io.tmpdir', tmpDir
@@ -28,7 +27,7 @@ tasks.withType(Javadoc).configureEach {
 }
 
 dependencies {
-    implementation(platform("software.amazon.awssdk:bom:2.20.56"))
+    implementation(platform("software.amazon.awssdk:bom:2.20.97"))
     implementation("software.amazon.awssdk:codeartifact")
     implementation("software.amazon.awssdk:sso")
 

--- a/plugins/src/main/java/co/bound/codeartifact/CodeArtifactPluginExtension.java
+++ b/plugins/src/main/java/co/bound/codeartifact/CodeArtifactPluginExtension.java
@@ -1,5 +1,7 @@
 package co.bound.codeartifact;
 
+import co.bound.codeartifact.internal.SerializableAction;
+import org.gradle.api.artifacts.repositories.MavenRepositoryContentDescriptor;
 import org.gradle.api.provider.Property;
 
 public abstract class CodeArtifactPluginExtension {
@@ -10,4 +12,6 @@ public abstract class CodeArtifactPluginExtension {
     public abstract Property<String> getRegion();
 
     public abstract Property<String> getRepo();
+
+    public abstract Property<SerializableAction<MavenRepositoryContentDescriptor>> getMavenContent();
 }

--- a/plugins/src/main/java/co/bound/codeartifact/CodeArtifactPluginExtension.java
+++ b/plugins/src/main/java/co/bound/codeartifact/CodeArtifactPluginExtension.java
@@ -3,6 +3,8 @@ package co.bound.codeartifact;
 import org.gradle.api.provider.Property;
 
 public abstract class CodeArtifactPluginExtension {
+    public static final String REPOSITORY_NAME = "codeartifact";
+
     public abstract Property<String> getDomain();
 
     public abstract Property<String> getAccountId();

--- a/plugins/src/main/java/co/bound/codeartifact/CodeArtifactPluginExtension.java
+++ b/plugins/src/main/java/co/bound/codeartifact/CodeArtifactPluginExtension.java
@@ -13,5 +13,5 @@ public abstract class CodeArtifactPluginExtension {
 
     public abstract Property<String> getRepo();
 
-    public abstract Property<SerializableAction<MavenRepositoryContentDescriptor>> getMavenContent();
+    public abstract Property<SerializableAction<MavenRepositoryContentDescriptor>> getContent();
 }

--- a/plugins/src/main/java/co/bound/codeartifact/CodeArtifactPluginExtension.java
+++ b/plugins/src/main/java/co/bound/codeartifact/CodeArtifactPluginExtension.java
@@ -1,7 +1,5 @@
 package co.bound.codeartifact;
 
-import co.bound.codeartifact.internal.SerializableAction;
-import org.gradle.api.artifacts.repositories.MavenRepositoryContentDescriptor;
 import org.gradle.api.provider.Property;
 
 public abstract class CodeArtifactPluginExtension {
@@ -12,6 +10,4 @@ public abstract class CodeArtifactPluginExtension {
     public abstract Property<String> getRegion();
 
     public abstract Property<String> getRepo();
-
-    public abstract Property<SerializableAction<MavenRepositoryContentDescriptor>> getContent();
 }

--- a/plugins/src/main/java/co/bound/codeartifact/CodeArtifactRepoProvider.java
+++ b/plugins/src/main/java/co/bound/codeartifact/CodeArtifactRepoProvider.java
@@ -18,7 +18,6 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.Optional;
 import java.util.Properties;
 
 public abstract class CodeArtifactRepoProvider implements BuildService<CodeArtifactRepoProvider.Params> {
@@ -42,8 +41,9 @@ public abstract class CodeArtifactRepoProvider implements BuildService<CodeArtif
                 }
             }
         });
-        Optional.ofNullable(params.getMavenContent().getOrNull())
-                .ifPresent(spec::mavenContent);
+        if (params.getMavenContent().isPresent()) {
+            spec.mavenContent(params.getMavenContent().get());
+        }
     }
 
     private GetAuthorizationTokenResponse token = null;

--- a/plugins/src/main/java/co/bound/codeartifact/CodeArtifactRepoProvider.java
+++ b/plugins/src/main/java/co/bound/codeartifact/CodeArtifactRepoProvider.java
@@ -1,7 +1,9 @@
 package co.bound.codeartifact;
 
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
+import org.gradle.api.Action;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.api.artifacts.repositories.MavenRepositoryContentDescriptor;
 import org.gradle.api.provider.Property;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
@@ -16,6 +18,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.Properties;
 
 public abstract class CodeArtifactRepoProvider implements BuildService<CodeArtifactRepoProvider.Params> {
@@ -39,6 +42,8 @@ public abstract class CodeArtifactRepoProvider implements BuildService<CodeArtif
                 }
             }
         });
+        Optional.ofNullable(params.getMavenContent().getOrNull())
+                .ifPresent(spec::mavenContent);
     }
 
     private GetAuthorizationTokenResponse token = null;
@@ -139,5 +144,7 @@ public abstract class CodeArtifactRepoProvider implements BuildService<CodeArtif
         Property<File> getGradleUserHome();
 
         Property<Boolean> getOffline();
+
+        Property<Action<MavenRepositoryContentDescriptor>> getMavenContent();
     }
 }

--- a/plugins/src/main/java/co/bound/codeartifact/CodeArtifactRepoProvider.java
+++ b/plugins/src/main/java/co/bound/codeartifact/CodeArtifactRepoProvider.java
@@ -19,14 +19,15 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Properties;
 
+import static co.bound.codeartifact.CodeArtifactPluginExtension.REPOSITORY_NAME;
+
 public abstract class CodeArtifactRepoProvider implements BuildService<CodeArtifactRepoProvider.Params> {
-    private static final String CODEARTIFACT_REPOSITORY_NAME = "codeartifact";
 
     public void configureRepo(RepositoryHandler repositories) {
-        if (repositories.findByName(CODEARTIFACT_REPOSITORY_NAME) == null) {
-            repositories.maven(spec -> spec.setName(CODEARTIFACT_REPOSITORY_NAME));
+        if (repositories.findByName(REPOSITORY_NAME) == null) {
+            repositories.maven(spec -> spec.setName(REPOSITORY_NAME));
         }
-        repositories.named(CODEARTIFACT_REPOSITORY_NAME, spec -> configureRepo((MavenArtifactRepository) spec));
+        repositories.named(REPOSITORY_NAME, spec -> configureRepo((MavenArtifactRepository) spec));
     }
 
     private void configureRepo(MavenArtifactRepository spec) {

--- a/plugins/src/main/java/co/bound/codeartifact/PublishPlugin.java
+++ b/plugins/src/main/java/co/bound/codeartifact/PublishPlugin.java
@@ -29,7 +29,7 @@ public class PublishPlugin implements Plugin<Project> {
                         "Please apply the co.bound.codeartifact plugin in the settings file first and configure the codeartifact extension");
             }
             CodeArtifactRepoProvider provider = codeArtifactRepoProviderService.getService().get();
-            handler.maven(provider::configureRepo);
+            provider.configureRepo(handler);
         });
     }
 

--- a/plugins/src/main/java/co/bound/codeartifact/SettingsPlugin.java
+++ b/plugins/src/main/java/co/bound/codeartifact/SettingsPlugin.java
@@ -29,7 +29,7 @@ public class SettingsPlugin implements Plugin<Settings> {
                     params.getAccountId().set(codeartifact.getAccountId());
                     params.getRegion().set(codeartifact.getRegion());
                     params.getRepo().set(codeartifact.getRepo());
-                    params.getMavenContent().set(codeartifact.getMavenContent());
+                    params.getMavenContent().set(codeartifact.getContent());
                     params.getGradleUserHome().set(settings.getStartParameter().getGradleUserHomeDir());
                     params.getOffline().set(settings.getStartParameter().isOffline());
                 }));

--- a/plugins/src/main/java/co/bound/codeartifact/SettingsPlugin.java
+++ b/plugins/src/main/java/co/bound/codeartifact/SettingsPlugin.java
@@ -29,6 +29,7 @@ public class SettingsPlugin implements Plugin<Settings> {
                     params.getAccountId().set(codeartifact.getAccountId());
                     params.getRegion().set(codeartifact.getRegion());
                     params.getRepo().set(codeartifact.getRepo());
+                    params.getMavenContent().set(codeartifact.getMavenContent());
                     params.getGradleUserHome().set(settings.getStartParameter().getGradleUserHomeDir());
                     params.getOffline().set(settings.getStartParameter().isOffline());
                 }));

--- a/plugins/src/main/java/co/bound/codeartifact/SettingsPlugin.java
+++ b/plugins/src/main/java/co/bound/codeartifact/SettingsPlugin.java
@@ -29,19 +29,19 @@ public class SettingsPlugin implements Plugin<Settings> {
                     params.getAccountId().set(codeartifact.getAccountId());
                     params.getRegion().set(codeartifact.getRegion());
                     params.getRepo().set(codeartifact.getRepo());
-                    params.getMavenContent().set(codeartifact.getContent());
                     params.getGradleUserHome().set(settings.getStartParameter().getGradleUserHomeDir());
                     params.getOffline().set(settings.getStartParameter().isOffline());
                 }));
 
         gradle.settingsEvaluated(ignore -> {
+            CodeArtifactRepoProvider repoProvider = serviceProvider.get();
             settings.pluginManagement(management ->
-                    management.repositories(repositories ->
-                            repositories.maven(serviceProvider.get()::configureRepo)));
+                    management.repositories(repoProvider::configureRepo)
+            );
             //noinspection UnstableApiUsage
             settings.dependencyResolutionManagement(management ->
-                    management.repositories(handler ->
-                            handler.maven(serviceProvider.get()::configureRepo)));
+                    management.repositories(repoProvider::configureRepo)
+            );
         });
     }
 }

--- a/plugins/src/main/java/co/bound/codeartifact/internal/SerializableAction.java
+++ b/plugins/src/main/java/co/bound/codeartifact/internal/SerializableAction.java
@@ -1,8 +1,0 @@
-package co.bound.codeartifact.internal;
-
-import org.gradle.api.Action;
-
-import java.io.Serializable;
-
-public interface SerializableAction<T> extends Action<T>, Serializable {
-}

--- a/plugins/src/main/java/co/bound/codeartifact/internal/SerializableAction.java
+++ b/plugins/src/main/java/co/bound/codeartifact/internal/SerializableAction.java
@@ -1,0 +1,8 @@
+package co.bound.codeartifact.internal;
+
+import org.gradle.api.Action;
+
+import java.io.Serializable;
+
+public interface SerializableAction<T> extends Action<T>, Serializable {
+}

--- a/plugins/src/test/groovy/co/bound/codeartifact/CodeArtifactPluginTest.groovy
+++ b/plugins/src/test/groovy/co/bound/codeartifact/CodeArtifactPluginTest.groovy
@@ -37,7 +37,7 @@ class CodeArtifactPluginTest extends PluginTest {
         ]
     }
 
-    def "searches for plugins in configured CodeArtifact repository"() {
+    def "searches for plugins in configured CodeArtifact repository - Groovy DSL"() {
         given:
         givenCodeArtifactWillReturnAuthToken()
         givenCodeArtifactPluginIsConfigured()
@@ -61,7 +61,7 @@ class CodeArtifactPluginTest extends PluginTest {
         gradleVersion << gradleVersions()
     }
 
-    def "searches for plugins in configured CodeArtifact repository for kotlin"() {
+    def "searches for plugins in configured CodeArtifact repository for - Kotlin DSL"() {
         given:
         givenCodeArtifactWillReturnAuthToken()
         useKotlinBuildScript()

--- a/plugins/src/test/groovy/co/bound/codeartifact/CodeArtifactPluginTest.groovy
+++ b/plugins/src/test/groovy/co/bound/codeartifact/CodeArtifactPluginTest.groovy
@@ -64,9 +64,7 @@ class CodeArtifactPluginTest extends PluginTest {
     def "searches for plugins in configured CodeArtifact repository for kotlin"() {
         given:
         givenCodeArtifactWillReturnAuthToken()
-        def settingsKt = file('settings.gradle.kts')
-        settingsFile.renameTo(settingsKt)
-        settingsFile = settingsKt
+        useKotlinBuildScript()
         settingsFile.setText("""
             plugins {
                 id("co.bound.codeartifact")
@@ -79,9 +77,6 @@ class CodeArtifactPluginTest extends PluginTest {
             }
             ${settingsFile.text}
         """)
-        def buildKt = file('build.gradle.kts')
-        buildFile.renameTo(buildKt)
-        buildFile = buildKt
         buildFile << """
             plugins {
                 id("foo.bar").version("42")
@@ -106,9 +101,7 @@ class CodeArtifactPluginTest extends PluginTest {
         given:
         givenCodeArtifactWillReturnAuthToken()
         file("gradle.properties") << "systemProp.org.gradle.unsafe.kotlin.assignment=true"
-        def settingsKt = file('settings.gradle.kts')
-        settingsFile.renameTo(settingsKt)
-        settingsFile = settingsKt
+        useKotlinBuildScript()
         settingsFile.setText("""
             plugins {
                 id("co.bound.codeartifact")
@@ -118,15 +111,12 @@ class CodeArtifactPluginTest extends PluginTest {
                 accountId = "$accountId"
                 region = "$region"
                 repo = "$repo"
-                mavenContent.set() {
+                content.set() {
                     includeGroup("foo.other") 
                 }
             }
             ${settingsFile.text}
         """)
-        def buildKt = file('build.gradle.kts')
-        buildFile.renameTo(buildKt)
-        buildFile = buildKt
         buildFile << """
             plugins {
                 id("foo.bar").version("42")

--- a/plugins/src/test/groovy/co/bound/codeartifact/CodeArtifactPluginTest.groovy
+++ b/plugins/src/test/groovy/co/bound/codeartifact/CodeArtifactPluginTest.groovy
@@ -2,7 +2,13 @@ package co.bound.codeartifact
 
 import org.gradle.util.GradleVersion
 
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl
+import static com.github.tomakehurst.wiremock.client.WireMock.get
+import static com.github.tomakehurst.wiremock.client.WireMock.head
+import static com.github.tomakehurst.wiremock.client.WireMock.ok
+import static com.github.tomakehurst.wiremock.client.WireMock.okXml
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching
+import static com.github.tomakehurst.wiremock.http.RequestMethod.GET
 import static com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.allRequests
 import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.newRequestPattern
@@ -49,6 +55,7 @@ class CodeArtifactPluginTest extends PluginTest {
         result.output.contains("Searched in the following repositories:")
         result.output.contains("codeartifact(${wiremock.baseUrl()}/${domain}-${accountId}.d.codeartifact.${region}.amazonaws.com/maven/$repo/)")
         wiremock.verify(1, newRequestPattern(POST, urlMatching("/v1/authorization-token.*")))
+        wiremock.verify(1, newRequestPattern(GET, anyUrl()))
 
         where:
         gradleVersion << gradleVersions()
@@ -64,7 +71,7 @@ class CodeArtifactPluginTest extends PluginTest {
             plugins {
                 id("co.bound.codeartifact")
             }
-            codeartifact{
+            codeartifact {
                 domain.set("$domain")
                 accountId.set("$accountId")
                 region.set("$region")
@@ -89,9 +96,52 @@ class CodeArtifactPluginTest extends PluginTest {
         result.output.contains("Searched in the following repositories:")
         result.output.contains("codeartifact(${wiremock.baseUrl()}/${domain}-${accountId}.d.codeartifact.${region}.amazonaws.com/maven/$repo/)")
         wiremock.verify(1, newRequestPattern(POST, urlMatching("/v1/authorization-token.*")))
+        wiremock.verify(1, newRequestPattern(GET, anyUrl()))
 
         where:
         gradleVersion << gradleVersions()
+    }
+
+    def "can configure repository filters"() {
+        given:
+        givenCodeArtifactWillReturnAuthToken()
+        file("gradle.properties") << "systemProp.org.gradle.unsafe.kotlin.assignment=true"
+        def settingsKt = file('settings.gradle.kts')
+        settingsFile.renameTo(settingsKt)
+        settingsFile = settingsKt
+        settingsFile.setText("""
+            plugins {
+                id("co.bound.codeartifact")
+            }
+            codeartifact {
+                domain = "$domain"
+                accountId = "$accountId"
+                region = "$region"
+                repo = "$repo"
+                mavenContent.set() {
+                    includeGroup("foo.other") 
+                }
+            }
+            ${settingsFile.text}
+        """)
+        def buildKt = file('build.gradle.kts')
+        buildFile.renameTo(buildKt)
+        buildFile = buildKt
+        buildFile << """
+            plugins {
+                id("foo.bar").version("42")
+            }
+        """
+
+        when:
+        def result = runTaskWithFailure(GradleVersion.current().getVersion(), "tasks", "-i")
+
+        then:
+        result.output.contains("Plugin [id: 'foo.bar', version: '42'] was not found in any of the following sources:")
+        result.output.contains("Searched in the following repositories:")
+        result.output.contains("codeartifact(${wiremock.baseUrl()}/${domain}-${accountId}.d.codeartifact.${region}.amazonaws.com/maven/$repo/)")
+        wiremock.verify(1, newRequestPattern(POST, urlMatching("/v1/authorization-token.*")))
+        wiremock.verify(0, newRequestPattern(GET, anyUrl()))
     }
 
     def "does not fetch the token for offline mode"() {
@@ -121,29 +171,53 @@ class CodeArtifactPluginTest extends PluginTest {
         given:
         givenCodeArtifactWillReturnAuthToken()
         givenCodeArtifactPluginIsConfigured()
+        wiremock.stubFor(head(anyUrl()).willReturn(ok()))
+        wiremock.stubFor(get(urlMatching(".*/42-SNAPSHOT/maven-metadata.xml"))
+                .willReturn(okXml("""\
+            <metadata>
+              <groupId>foo</groupId>
+              <artifactId>bar</artifactId>
+              <versioning>
+                <versions>
+                  <version>42-SNAPSHOT</version>
+                </versions>
+              </versioning>
+            </metadata>""".stripIndent())))
+        wiremock.stubFor(get(urlMatching(".*/bar-42-SNAPSHOT.pom"))
+                .willReturn(okXml("""\
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>foo</groupId>
+              <artifactId>bar</artifactId>
+              <version>42-SNAPSHOT</version>
+            </project>""".stripIndent())))
+        wiremock.stubFor(get(urlMatching(".*/bar-42-SNAPSHOT.pom.sha1")).willReturn(ok("1")))
+        wiremock.stubFor(get(urlMatching(".*/bar-42-SNAPSHOT.jar"))
+        // minimal empty zip file
+                .willReturn(ok().withBody(new byte[]{0x50, 0x4B, 0x05, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})))
+        wiremock.stubFor(get(urlMatching(".*/bar-42-SNAPSHOT.jar.sha1")).willReturn(ok("2")))
         buildFile << """
             plugins {
                 id("java") 
             }
             dependencies {
-                implementation("foo:bar:42")
+                implementation("foo:bar:42-SNAPSHOT")
             }
         """
-        file("src/main/java/Foo.java") << "class Foo {}"
+        file("src/main/java/bar").mkdirs()
+        file("src/main/java/bar/Foo.java") << """\
+            package bar;
+            class Foo {}""".stripIndent()
 
         when:
-        def result1 = runTaskWithFailure(gradleVersion, "build")
-        def result2 = runTaskWithFailure(gradleVersion, "build")
+        runTask(gradleVersion, "build", "-i")
+        runTask(gradleVersion, "build", "--refresh-dependencies")
 
         then:
-        result1.output.contains("Could not find foo:bar:42")
-        result1.output.contains("Searched in the following locations")
-        result1.output.contains("- ${wiremock.baseUrl()}/${domain}-${accountId}.d.codeartifact.${region}.amazonaws.com/maven/$repo/foo/bar/42/bar-42.pom")
-        result2.output.contains("Could not find foo:bar:42")
-        result2.output.contains("Searched in the following locations")
-        result2.output.contains("- ${wiremock.baseUrl()}/${domain}-${accountId}.d.codeartifact.${region}.amazonaws.com/maven/$repo/foo/bar/42/bar-42.pom")
         // credentials are cached
         wiremock.verify(1, newRequestPattern(POST, urlMatching("/v1/authorization-token.*")))
+        wiremock.verify(2, newRequestPattern(GET, urlMatching(".*/bar-42-SNAPSHOT.jar")))
+        wiremock.findAllUnmatchedRequests().isEmpty()
 
         where:
         gradleVersion << gradleVersions()

--- a/plugins/src/test/groovy/co/bound/codeartifact/CodeArtifactPluginTest.groovy
+++ b/plugins/src/test/groovy/co/bound/codeartifact/CodeArtifactPluginTest.groovy
@@ -173,7 +173,7 @@ class CodeArtifactPluginTest extends PluginTest {
         givenCodeArtifactPluginIsConfigured()
         wiremock.stubFor(head(anyUrl()).willReturn(ok()))
         wiremock.stubFor(get(urlMatching(".*/42-SNAPSHOT/maven-metadata.xml"))
-                .willReturn(okXml("""\
+                .willReturn(okXml("""
             <metadata>
               <groupId>foo</groupId>
               <artifactId>bar</artifactId>
@@ -182,15 +182,15 @@ class CodeArtifactPluginTest extends PluginTest {
                   <version>42-SNAPSHOT</version>
                 </versions>
               </versioning>
-            </metadata>""".stripIndent())))
+            </metadata>""")))
         wiremock.stubFor(get(urlMatching(".*/bar-42-SNAPSHOT.pom"))
-                .willReturn(okXml("""\
+                .willReturn(okXml("""
             <project>
               <modelVersion>4.0.0</modelVersion>
               <groupId>foo</groupId>
               <artifactId>bar</artifactId>
               <version>42-SNAPSHOT</version>
-            </project>""".stripIndent())))
+            </project>""")))
         wiremock.stubFor(get(urlMatching(".*/bar-42-SNAPSHOT.pom.sha1")).willReturn(ok("1")))
         wiremock.stubFor(get(urlMatching(".*/bar-42-SNAPSHOT.jar"))
         // minimal empty zip file
@@ -205,9 +205,10 @@ class CodeArtifactPluginTest extends PluginTest {
             }
         """
         file("src/main/java/bar").mkdirs()
-        file("src/main/java/bar/Foo.java") << """\
+        file("src/main/java/bar/Foo.java") << """
             package bar;
-            class Foo {}""".stripIndent()
+            class Foo {}
+        """
 
         when:
         runTask(gradleVersion, "build", "-i")

--- a/plugins/src/test/groovy/co/bound/codeartifact/PluginTest.groovy
+++ b/plugins/src/test/groovy/co/bound/codeartifact/PluginTest.groovy
@@ -105,4 +105,13 @@ abstract class PluginTest extends Specification {
         println(result.output)
         return result
     }
+
+    void useKotlinBuildScript() {
+        def settingsKt = file('settings.gradle.kts')
+        settingsFile.renameTo(settingsKt)
+        settingsFile = settingsKt
+        def buildKt = file('build.gradle.kts')
+        buildFile.renameTo(buildKt)
+        buildFile = buildKt
+    }
 }

--- a/plugins/src/test/groovy/co/bound/codeartifact/PluginTest.groovy
+++ b/plugins/src/test/groovy/co/bound/codeartifact/PluginTest.groovy
@@ -65,7 +65,7 @@ abstract class PluginTest extends Specification {
     void givenCodeArtifactWillReturnAuthToken() {
         wiremock.stubFor(
                 WireMock.post(WireMock.urlMatching("/v1/authorization-token.*"))
-                            .willReturn(WireMock.jsonResponse("""{"authorizationToken":"foobar","expiration":${System.currentTimeSeconds()+30}}""", 200))
+                            .willReturn(WireMock.jsonResponse("""{"authorizationToken":"foobar","expiration":${System.currentTimeSeconds()+60}}""", 200))
         )
     }
 

--- a/plugins/src/test/groovy/co/bound/codeartifact/PluginTest.groovy
+++ b/plugins/src/test/groovy/co/bound/codeartifact/PluginTest.groovy
@@ -88,9 +88,10 @@ abstract class PluginTest extends Specification {
         return ["7.6.1", "8.0.2", GradleVersion.current().getVersion()]
     }
 
-    BuildResult runTask(String task) {
+    BuildResult runTask(Object gradleVersion, String... tasks) {
         def result = gradleRunner
-                .withArguments(task, '--stacktrace')
+                .withGradleVersion(gradleVersion as String)
+                .withArguments((tasks + ['--stacktrace']) as List<String>)
                 .build()
         println(result.output)
         return result


### PR DESCRIPTION
This is a different approach to allow repository filtering that https://github.com/boundrates/codeartifact-gradle-plugin/pull/22 proposed.

Instead of passing additional repository configuration actions via the CodeArtifact extension, allow the CodeArtifact repository to be referenced by name, which in turn allows customization via Gradle's standard MavenArtifactRepository APIs.

For example, when `codeartifact` extension is configured, the user can further customize the repository like this:
```groovy
repositories {
    maven {
        name("codeartifact")
        content {
            includeGroup("foo.other") 
        }
    }
}
```

Note that the Kotlin's version requires the URL to be specified. Since the repository URL is configured by the plugin, any valid URL will do to satisfy the validation. Not pretty, but it works:
```kotlin
repositories {
    maven {
        name = "codeartifact"
        // Kotlin's version requires some URL to be specified
        // Whatever we specify here will be overriden and correctly configured by the codeartifact plugin
        url = uri("https://www.foo.bar") 
        content {
            includeGroup("foo.other") 
        }
    }
}
```