### PR TITLE
Add SSOIDC support for AWS creddentials

### DIFF
--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation(platform("software.amazon.awssdk:bom:2.23.8"))
     implementation("software.amazon.awssdk:codeartifact")
     implementation("software.amazon.awssdk:sso")
+    implementation("software.amazon.awssdk:ssoidc")
 
     testImplementation(platform("org.spockframework:spock-bom:2.3-groovy-3.0"))
     testImplementation("org.spockframework:spock-core")


### PR DESCRIPTION
Should solve the following error when using sso credentials

_ProfileCredentialsProvider(profileName=default, profileFile=ProfileFile(sections=[profiles, sso-session], profiles=[Profile(name=default, properties=[sso_session, output, sso_role_name, region, sso_account_id])])): To use SSO OIDC related properties in the 'default' profile, the 'ssooidc' service module must be on the class path._
