### PR TITLE
Add SSOOIDC support for AWS credentials

### DIFF
--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "co.bound"
-version = "1.5.0"
+version = "1.5.1"
 
 tasks.named("publish") {
     dependsOn("check")


### PR DESCRIPTION
Should solve the following error when using sso credentials

ProfileCredentialsProvider(profileName=default, profileFile=ProfileFile(sections=[profiles, sso-session], profiles=[Profile(name=default, properties=[sso_session, output, sso_role_name, region, sso_account_id])])): To use SSO OIDC related properties in the 'default' profile, the 'ssooidc' service module must be on the class path.